### PR TITLE
Change parse to use PxDateFormat

### DIFF
--- a/PCAxis.Serializers.JsonStat/Model/JsonStatDatasetBase.cs
+++ b/PCAxis.Serializers.JsonStat/Model/JsonStatDatasetBase.cs
@@ -3,6 +3,7 @@
 	using Newtonsoft.Json;
 	using System;
     using System.Collections.Generic;
+    using System.Globalization;
 
     [Serializable]
     public class JsonStatDatasetBase
@@ -48,7 +49,7 @@
         public string updated
         {
             get { return _updated.ToString("yyyy-MM-ddTHH:mm:ssZ"); }
-            set { _updated = DateTime.Parse(value).ToUniversalTime(); }
+            set { _updated = DateTime.ParseExact(value, Paxiom.PXConstant.PXDATEFORMAT, CultureInfo.InvariantCulture).ToUniversalTime(); }
         }
         /// <summary>
         /// It contains the data sorted according to the dataset dimensions. It usually takes the form of an array where missing values are expressed as nulls.


### PR DESCRIPTION
Parser now uses PxDateFormat to avoid exceptions while handling certain formats.
Fixes statisticssweden/PxWeb#220